### PR TITLE
Make Instruction fields public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ where
     M: ByteSized + Copy + Debug + PartialEq,
     A: ByteSized + Copy + Debug + PartialEq,
 {
-    mnemonic: M,
-    addressing_mode: A,
+    pub mnemonic: M,
+    pub addressing_mode: A,
 }
 
 impl<M, A> Instruction<M, A>


### PR DESCRIPTION
# Introduction
Small PR to make instruction fields `mnemonic` and `addressing_mode` public.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
