### PR TITLE
Mnemonic and Addressing Mode Enums

### DIFF
--- a/src/addressing_mode.rs
+++ b/src/addressing_mode.rs
@@ -41,6 +41,12 @@ impl From<Absolute> for Vec<u8> {
     }
 }
 
+impl From<Absolute> for AddressingMode {
+    fn from(src: Absolute) -> Self {
+        AddressingMode::Absolute(src.0)
+    }
+}
+
 /// AbsoluteIndexedWithX represents an address whose value is stored at an X
 /// register offset from the operand value. Example being LLHH + X.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
@@ -77,6 +83,12 @@ impl From<AbsoluteIndexedWithX> for u16 {
 impl From<AbsoluteIndexedWithX> for Vec<u8> {
     fn from(src: AbsoluteIndexedWithX) -> Self {
         src.0.to_le_bytes().to_vec()
+    }
+}
+
+impl From<AbsoluteIndexedWithX> for AddressingMode {
+    fn from(src: AbsoluteIndexedWithX) -> Self {
+        AddressingMode::AbsoluteIndexedWithX(src.0)
     }
 }
 
@@ -119,6 +131,12 @@ impl From<AbsoluteIndexedWithY> for Vec<u8> {
     }
 }
 
+impl From<AbsoluteIndexedWithY> for AddressingMode {
+    fn from(src: AbsoluteIndexedWithY) -> Self {
+        AddressingMode::AbsoluteIndexedWithY(src.0)
+    }
+}
+
 /// Accumulator addressing mode represents an operand whose value is sourced
 /// from the ACC register.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
@@ -139,6 +157,12 @@ impl<'a> Parser<'a, &'a [u8], Accumulator> for Accumulator {
 impl From<Accumulator> for Vec<u8> {
     fn from(_: Accumulator) -> Self {
         vec![]
+    }
+}
+
+impl From<Accumulator> for AddressingMode {
+    fn from(_: Accumulator) -> Self {
+        AddressingMode::Accumulator
     }
 }
 
@@ -175,6 +199,12 @@ impl From<Immediate> for Vec<u8> {
     }
 }
 
+impl From<Immediate> for AddressingMode {
+    fn from(src: Immediate) -> Self {
+        AddressingMode::Immediate(src.0)
+    }
+}
+
 /// Implied addressing mode. This is signified by no addressing mode
 /// arguments. An example instruction with an implied addressing mode would be.
 /// `nop`
@@ -196,6 +226,12 @@ impl<'a> Parser<'a, &'a [u8], Implied> for Implied {
 impl From<Implied> for Vec<u8> {
     fn from(_: Implied) -> Self {
         vec![]
+    }
+}
+
+impl From<Implied> for AddressingMode {
+    fn from(_: Implied) -> Self {
+        AddressingMode::Implied
     }
 }
 
@@ -238,6 +274,12 @@ impl From<Indirect> for Vec<u8> {
     }
 }
 
+impl From<Indirect> for AddressingMode {
+    fn from(src: Indirect) -> Self {
+        AddressingMode::Indirect(src.0)
+    }
+}
+
 /// IndirectYIndexed represents an address whose value is stored as a Y
 /// register offset for an indirect address defined as the operand. Example
 /// being (LL, LL + 1) + Y.
@@ -272,6 +314,12 @@ impl From<IndirectYIndexed> for Vec<u8> {
     }
 }
 
+impl From<IndirectYIndexed> for AddressingMode {
+    fn from(src: IndirectYIndexed) -> Self {
+        AddressingMode::IndirectYIndexed(src.0)
+    }
+}
+
 /// XIndexedIndirect represents an address whose value is stored as an X
 /// register offset for sequential bytes of an address word. Example being
 /// LL + X, LL + X + 1.
@@ -303,6 +351,12 @@ impl From<XIndexedIndirect> for u8 {
 impl From<XIndexedIndirect> for Vec<u8> {
     fn from(src: XIndexedIndirect) -> Self {
         src.0.to_le_bytes().to_vec()
+    }
+}
+
+impl From<XIndexedIndirect> for AddressingMode {
+    fn from(src: XIndexedIndirect) -> Self {
+        AddressingMode::XIndexedIndirect(src.0)
     }
 }
 
@@ -346,6 +400,12 @@ impl From<Relative> for Vec<u8> {
     }
 }
 
+impl From<Relative> for AddressingMode {
+    fn from(src: Relative) -> Self {
+        AddressingMode::Relative(src.0)
+    }
+}
+
 /// ZeroPage wraps a u8 and represents an address in 00LL format.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ZeroPage(pub u8);
@@ -376,6 +436,12 @@ impl From<ZeroPage> for u8 {
 impl From<ZeroPage> for Vec<u8> {
     fn from(src: ZeroPage) -> Self {
         vec![src.0]
+    }
+}
+
+impl From<ZeroPage> for AddressingMode {
+    fn from(src: ZeroPage) -> Self {
+        AddressingMode::ZeroPage(src.0)
     }
 }
 
@@ -412,6 +478,12 @@ impl From<ZeroPageIndexedWithX> for Vec<u8> {
     }
 }
 
+impl From<ZeroPageIndexedWithX> for AddressingMode {
+    fn from(src: ZeroPageIndexedWithX) -> Self {
+        AddressingMode::ZeroPageIndexedWithX(src.0)
+    }
+}
+
 /// ZeroPageIndexedWithY wraps a u8 and represents an address in the zeropage +
 /// the value of the Y register in the format of `00LL + y`.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
@@ -442,5 +514,65 @@ impl From<ZeroPageIndexedWithY> for u8 {
 impl From<ZeroPageIndexedWithY> for Vec<u8> {
     fn from(src: ZeroPageIndexedWithY) -> Self {
         vec![src.0]
+    }
+}
+
+impl From<ZeroPageIndexedWithY> for AddressingMode {
+    fn from(src: ZeroPageIndexedWithY) -> Self {
+        AddressingMode::ZeroPageIndexedWithY(src.0)
+    }
+}
+
+/// AddressingMode captures the Addressing mode type with a corresponding
+/// operand of the appropriate bit length.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum AddressingMode {
+    Accumulator,
+    Implied,
+    Immediate(u8),
+    Absolute(u16),
+    ZeroPage(u8),
+    Relative(i8),
+    Indirect(u16),
+    AbsoluteIndexedWithX(u16),
+    AbsoluteIndexedWithY(u16),
+    ZeroPageIndexedWithX(u8),
+    ZeroPageIndexedWithY(u8),
+    XIndexedIndirect(u8),
+    IndirectYIndexed(u8),
+}
+
+impl Into<Vec<u8>> for AddressingMode {
+    fn into(self) -> Vec<u8> {
+        match self {
+            AddressingMode::Immediate(operand) => vec![operand],
+            AddressingMode::Absolute(operand) => operand.to_le_bytes().to_vec(),
+            AddressingMode::ZeroPage(operand) => vec![operand],
+            AddressingMode::Relative(operand) => {
+                let o_to_u8 = unsafe { std::mem::transmute::<i8, u8>(operand) };
+                vec![o_to_u8]
+            }
+            AddressingMode::Indirect(operand) => operand.to_le_bytes().to_vec(),
+            AddressingMode::AbsoluteIndexedWithX(operand) => operand.to_le_bytes().to_vec(),
+            AddressingMode::AbsoluteIndexedWithY(operand) => operand.to_le_bytes().to_vec(),
+            AddressingMode::ZeroPageIndexedWithX(operand) => vec![operand],
+            AddressingMode::ZeroPageIndexedWithY(operand) => vec![operand],
+            AddressingMode::XIndexedIndirect(operand) => vec![operand],
+            AddressingMode::IndirectYIndexed(operand) => vec![operand],
+            _ => vec![],
+        }
+    }
+}
+
+impl crate::ByteSized for AddressingMode {
+    fn byte_size(&self) -> usize {
+        match self {
+            AddressingMode::Accumulator | AddressingMode::Implied => 0,
+            AddressingMode::Absolute(_)
+            | AddressingMode::Indirect(_)
+            | AddressingMode::AbsoluteIndexedWithX(_)
+            | AddressingMode::AbsoluteIndexedWithY(_) => 2,
+            _ => 1,
+        }
     }
 }

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -1,6 +1,20 @@
 extern crate parcel;
 use crate::ByteSized;
 
+/// Represents various conversion errors between mnemnoic types.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MnemonicErr {
+    ConversionErr,
+}
+
+impl std::fmt::Display for MnemonicErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConversionErr => write!(f, "Unable to convert to mnemonic"),
+        }
+    }
+}
+
 macro_rules! generate_mnemonic_parser_and_offset {
     ($mnemonic:ty, $text:literal, $opcode:literal) => {
         impl ByteSized for $mnemonic {}
@@ -45,6 +59,24 @@ macro_rules! generate_mnemonic_parser_and_offset {
                     parcel::parsers::character::expect_str($text),
                     |_| <$mnemonic>::default()
                 ).parse(input)
+            }
+        }
+
+        impl std::convert::TryFrom<&str> for $mnemonic {
+            type Error = MnemonicErr;
+
+            fn try_from(src: &str) -> Result<$mnemonic, Self::Error> {
+                if src == $text {
+                    Ok(<$mnemonic>::default())
+                } else {
+                    Err(MnemonicErr::ConversionErr)
+                }
+            }
+        }
+
+        impl std::convert::From<$mnemonic> for &str {
+            fn from(_: $mnemonic) -> &'static str {
+               $text
             }
         }
     };
@@ -402,3 +434,155 @@ generate_mnemonic_parser_and_offset!(BRK, "brk", 0x00);
 pub struct NOP;
 
 generate_mnemonic_parser_and_offset!(NOP, "nop", 0xea);
+
+/// Mnemonic stores an enum representing every possible mnemonic.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Mnemonic {
+    // Load-Store
+    LDA,
+    LDX,
+    LDY,
+    STA,
+    STX,
+    STY,
+
+    // Arithmetic
+    ADC,
+    SBC,
+    INC,
+    INX,
+    INY,
+    DEC,
+    DEX,
+    DEY,
+
+    // Shift and Rotate
+    ASL,
+    LSR,
+    ROL,
+    ROR,
+    AND,
+    ORA,
+    EOR,
+
+    // Compare and Test Bit
+    CMP,
+    CPX,
+    CPY,
+    BIT,
+
+    // Branch
+    BCC,
+    BCS,
+    BNE,
+    BEQ,
+    BPL,
+    BMI,
+    BVC,
+    BVS,
+
+    // Transfer
+    TAX,
+    TXA,
+    TAY,
+    TYA,
+    TSX,
+    TXS,
+
+    // Stack
+    PHA,
+    PLA,
+    PHP,
+    PLP,
+
+    // Subroutines and Jump
+    JMP,
+    JSR,
+    RTS,
+    RTI,
+
+    // Set and Clear
+    CLC,
+    SEC,
+    CLD,
+    SED,
+    CLI,
+    SEI,
+    CLV,
+
+    // Misc
+    BRK,
+    NOP,
+}
+
+impl crate::ByteSized for Mnemonic {
+    fn byte_size(&self) -> usize {
+        1
+    }
+}
+
+impl std::convert::TryFrom<&str> for Mnemonic {
+    type Error = String;
+
+    fn try_from(src: &str) -> Result<Mnemonic, Self::Error> {
+        match src {
+            "lda" => Ok(Mnemonic::LDA),
+            "ldx" => Ok(Mnemonic::LDX),
+            "ldy" => Ok(Mnemonic::LDY),
+            "sta" => Ok(Mnemonic::STA),
+            "stx" => Ok(Mnemonic::STX),
+            "sty" => Ok(Mnemonic::STY),
+            "adc" => Ok(Mnemonic::ADC),
+            "sbc" => Ok(Mnemonic::SBC),
+            "inc" => Ok(Mnemonic::INC),
+            "inx" => Ok(Mnemonic::INX),
+            "iny" => Ok(Mnemonic::INY),
+            "dec" => Ok(Mnemonic::DEC),
+            "dex" => Ok(Mnemonic::DEX),
+            "dey" => Ok(Mnemonic::DEY),
+            "asl" => Ok(Mnemonic::ASL),
+            "lsr" => Ok(Mnemonic::LSR),
+            "rol" => Ok(Mnemonic::ROL),
+            "ror" => Ok(Mnemonic::ROR),
+            "and" => Ok(Mnemonic::AND),
+            "ora" => Ok(Mnemonic::ORA),
+            "eor" => Ok(Mnemonic::EOR),
+            "cmp" => Ok(Mnemonic::CMP),
+            "cpx" => Ok(Mnemonic::CPX),
+            "cpy" => Ok(Mnemonic::CPY),
+            "bit" => Ok(Mnemonic::BIT),
+            "bcc" => Ok(Mnemonic::BCC),
+            "bcs" => Ok(Mnemonic::BCS),
+            "bnd" => Ok(Mnemonic::BNE),
+            "beq" => Ok(Mnemonic::BEQ),
+            "bpl" => Ok(Mnemonic::BPL),
+            "bmi" => Ok(Mnemonic::BMI),
+            "bvc" => Ok(Mnemonic::BVC),
+            "bvs" => Ok(Mnemonic::BVS),
+            "tax" => Ok(Mnemonic::TAX),
+            "txa" => Ok(Mnemonic::TXA),
+            "tay" => Ok(Mnemonic::TAY),
+            "tya" => Ok(Mnemonic::TYA),
+            "tsx" => Ok(Mnemonic::TSX),
+            "txs" => Ok(Mnemonic::TXS),
+            "pha" => Ok(Mnemonic::PHA),
+            "pla" => Ok(Mnemonic::PLA),
+            "php" => Ok(Mnemonic::PHP),
+            "plp" => Ok(Mnemonic::PLP),
+            "jmp" => Ok(Mnemonic::JMP),
+            "jsr" => Ok(Mnemonic::JSR),
+            "rts" => Ok(Mnemonic::RTS),
+            "rti" => Ok(Mnemonic::RTI),
+            "clc" => Ok(Mnemonic::CLC),
+            "sec" => Ok(Mnemonic::SEC),
+            "cld" => Ok(Mnemonic::CLD),
+            "sed" => Ok(Mnemonic::SED),
+            "cli" => Ok(Mnemonic::CLI),
+            "sei" => Ok(Mnemonic::SEI),
+            "clv" => Ok(Mnemonic::CLV),
+            "brk" => Ok(Mnemonic::BRK),
+            "nop" => Ok(Mnemonic::NOP),
+            _ => Err(format!("Invalid instruction: {}", src)),
+        }
+    }
+}


### PR DESCRIPTION
# Introduction
This PR implements enums for each of the Mnemonic and Addressing Modes along with conversion types from the more specific Mnemonic and Addressing Mode concrete types.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
