### PR TITLE
Add enum for addressingmode type

### DIFF
--- a/src/addressing_mode.rs
+++ b/src/addressing_mode.rs
@@ -576,3 +576,28 @@ impl crate::ByteSized for AddressingMode {
         }
     }
 }
+
+/// AddressingModeType captures the addressing mode type without the operand
+/// value.
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
+pub enum AddressingModeType {
+    Accumulator,
+    Implied,
+    Immediate,
+    Absolute,
+    ZeroPage,
+    Relative,
+    Indirect,
+    AbsoluteIndexedWithX,
+    AbsoluteIndexedWithY,
+    ZeroPageIndexedWithX,
+    ZeroPageIndexedWithY,
+    IndexedIndirect,
+    IndirectIndexed,
+}
+
+impl std::fmt::Display for AddressingModeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}


### PR DESCRIPTION
# Introduction
Small PR to add an `AddressingModeType` which represents an addressing mode without the operands.

# Linked Issues
resolves #21

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
