### PR TITLE
Fix Indirect variant names

### DIFF
--- a/src/addressing_mode.rs
+++ b/src/addressing_mode.rs
@@ -592,8 +592,8 @@ pub enum AddressingModeType {
     AbsoluteIndexedWithY,
     ZeroPageIndexedWithX,
     ZeroPageIndexedWithY,
-    IndexedIndirect,
-    IndirectIndexed,
+    XIndexedIndirect,
+    IndirectYIndexed,
 }
 
 impl std::fmt::Display for AddressingModeType {


### PR DESCRIPTION
# Introduction
Small bugfix to address misnamed variants:
- IndexedIndirect -> XIndexedIndirect
- IndirectIndexed -> IndirectYIndexed

# Linked Issues
#21 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
