### PR TITLE
Add new method to instructionvariant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,6 +637,19 @@ pub enum InstructionVariant {
     TYAImplied,
 }
 
+impl InstructionVariant {
+    /// new functions as a wrapper around TryFrom<(Mnemonic, AddressingMode)
+    /// and returning a Result. This functions identically other than requiring
+    /// that the TryFrom trait be imported to call this.
+    pub fn new(
+        m: mnemonic::Mnemonic,
+        am: addressing_mode::AddressingMode,
+    ) -> Result<Self, InstructionErr> {
+        use std::convert::TryFrom;
+        <InstructionVariant>::try_from((m, am))
+    }
+}
+
 /// Implements bytecode converstion for InstructionVariant by explicitly converting to the generic type.
 impl std::convert::From<InstructionVariant> for Bytecode {
     fn from(src: InstructionVariant) -> Bytecode {


### PR DESCRIPTION
# Introduction
This includes a small pr to include a `new` static method on the `InstructionVariant` type that takes a `mnemonic::Mnemonic` and an `addressing_mode::AddressingMode` and invokes calls out to the `TryFrom<(Mnemonic, AddressingMode)>` trait. Functionally this behaves exactly the same and really just provides a simple wrapper that doesn't require the TryFrom trait be included into local scope downstream.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
