### PR TITLE
fix: add missing semantic-release/exec dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: "lts/*"
       - name: Install dependencies
-        run: npm install --save-dev semantic-release @semantic-release/git @semantic-release/changelog
+        run: npm install --save-dev semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/exec
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Introduction
`@semantic-release/exec` was missing as an install dep.
# Linked Issues

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
