### PR TITLE
fix: update prepare.sh script path

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -8,7 +8,7 @@
 		[
 			"@semantic-release/exec",
 			{
-				"prepareCmd": "./bin/prepare.sh ${nextRelease.version}"
+				"prepareCmd": "./scripts/prepare.sh ${nextRelease.version}"
 			}
 		],
 		"@semantic-release/github",


### PR DESCRIPTION
# Introduction
Update the `prepare.sh` path from `./bin/prepare.sh` -> `./scripts/prepare.sh`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
