### PR TITLE
feat: bit decoding alongside parcel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -10,6 +8,7 @@ permissions:
 jobs:
   release:
     name: Release
+    environment: manual-release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,8 @@ authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"
 
 [dependencies]
-parcel = { git = "https://github.com/ncatelli/parcel", tag = "v2.0.1" }
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v2.0.1", optional = true }
+
+[features]
+default = ["parcel"]
+parcel = ["dep:parcel"]

--- a/src/addressing_mode.rs
+++ b/src/addressing_mode.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "parcel")]
 extern crate parcel;
+
 use crate::{ByteSized, CycleCost};
+
+#[cfg(feature = "parcel")]
 use parcel::{parsers::byte::any_byte, MatchStatus, ParseResult, Parser};
 
 ///  Absolute addressing mode represents a u16 represented constant address to a
@@ -13,6 +17,7 @@ impl ByteSized for Absolute {
     }
 }
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], Absolute> for Absolute {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], Absolute> {
         parcel::take_n(any_byte(), 2)
@@ -58,6 +63,7 @@ impl ByteSized for AbsoluteIndexedWithX {
     }
 }
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], AbsoluteIndexedWithX> for AbsoluteIndexedWithX {
     fn parse(
         &self,
@@ -106,6 +112,7 @@ impl ByteSized for AbsoluteIndexedWithY {
     }
 }
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], AbsoluteIndexedWithY> for AbsoluteIndexedWithY {
     fn parse(
         &self,
@@ -154,6 +161,7 @@ impl ByteSized for Accumulator {
     }
 }
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], Accumulator> for Accumulator {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], Accumulator> {
         let start = input.first().map_or(0, |i| i.0);
@@ -185,6 +193,7 @@ pub struct Immediate(pub u8);
 
 impl ByteSized for Immediate {}
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], Immediate> for Immediate {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], Immediate> {
         any_byte().map(Immediate).parse(input)
@@ -229,6 +238,7 @@ impl ByteSized for Implied {
     }
 }
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], Implied> for Implied {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], Implied> {
         let start = input.first().map_or(0, |i| i.0);
@@ -264,6 +274,7 @@ impl ByteSized for Indirect {
     }
 }
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], Indirect> for Indirect {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], Indirect> {
         parcel::take_n(any_byte(), 2)
@@ -306,6 +317,7 @@ pub struct IndirectYIndexed(pub u8);
 
 impl ByteSized for IndirectYIndexed {}
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], IndirectYIndexed> for IndirectYIndexed {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], IndirectYIndexed> {
         any_byte().map(IndirectYIndexed).parse(input)
@@ -346,6 +358,7 @@ pub struct XIndexedIndirect(pub u8);
 
 impl ByteSized for XIndexedIndirect {}
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], XIndexedIndirect> for XIndexedIndirect {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], XIndexedIndirect> {
         any_byte().map(XIndexedIndirect).parse(input)
@@ -386,6 +399,7 @@ pub struct Relative(pub i8);
 
 impl ByteSized for Relative {}
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], Relative> for Relative {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], Relative> {
         any_byte()
@@ -431,6 +445,7 @@ pub struct ZeroPage(pub u8);
 impl CycleCost for ZeroPage {}
 impl ByteSized for ZeroPage {}
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], ZeroPage> for ZeroPage {
     fn parse(&self, input: &'a [(usize, u8)]) -> ParseResult<&'a [(usize, u8)], ZeroPage> {
         any_byte().map(ZeroPage).parse(input)
@@ -470,6 +485,7 @@ pub struct ZeroPageIndexedWithX(pub u8);
 
 impl ByteSized for ZeroPageIndexedWithX {}
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], ZeroPageIndexedWithX> for ZeroPageIndexedWithX {
     fn parse(
         &self,
@@ -512,6 +528,7 @@ pub struct ZeroPageIndexedWithY(pub u8);
 
 impl ByteSized for ZeroPageIndexedWithY {}
 
+#[cfg(feature = "parcel")]
 impl<'a> Parser<'a, &'a [(usize, u8)], ZeroPageIndexedWithY> for ZeroPageIndexedWithY {
     fn parse(
         &self,

--- a/src/addressing_mode.rs
+++ b/src/addressing_mode.rs
@@ -566,6 +566,26 @@ pub enum AddressingMode {
     IndirectYIndexed(u8),
 }
 
+impl AddressingMode {
+    pub fn to_addressing_mode_type(&self) -> AddressingModeType {
+        match self {
+            AddressingMode::Accumulator => AddressingModeType::Accumulator,
+            AddressingMode::Implied => AddressingModeType::Implied,
+            AddressingMode::Immediate(_) => AddressingModeType::Immediate,
+            AddressingMode::Absolute(_) => AddressingModeType::Absolute,
+            AddressingMode::ZeroPage(_) => AddressingModeType::ZeroPage,
+            AddressingMode::Relative(_) => AddressingModeType::Relative,
+            AddressingMode::Indirect(_) => AddressingModeType::Indirect,
+            AddressingMode::AbsoluteIndexedWithX(_) => AddressingModeType::AbsoluteIndexedWithX,
+            AddressingMode::AbsoluteIndexedWithY(_) => AddressingModeType::AbsoluteIndexedWithY,
+            AddressingMode::ZeroPageIndexedWithX(_) => AddressingModeType::ZeroPageIndexedWithX,
+            AddressingMode::ZeroPageIndexedWithY(_) => AddressingModeType::ZeroPageIndexedWithY,
+            AddressingMode::XIndexedIndirect(_) => AddressingModeType::XIndexedIndirect,
+            AddressingMode::IndirectYIndexed(_) => AddressingModeType::IndirectYIndexed,
+        }
+    }
+}
+
 impl From<AddressingMode> for Vec<u8> {
     fn from(src: AddressingMode) -> Vec<u8> {
         match src {

--- a/src/bit_decoder.rs
+++ b/src/bit_decoder.rs
@@ -1,0 +1,197 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Opcode(u8);
+
+impl Opcode {
+    pub fn to_u8(self) -> u8 {
+        self.0
+    }
+
+    pub const fn a_bits(&self) -> u8 {
+        (self.0 >> 5) & 0x07
+    }
+
+    pub const fn b_bits(&self) -> u8 {
+        (self.0 >> 2) & 0x07
+    }
+
+    pub const fn c_bits(&self) -> u8 {
+        self.0 & 0x03
+    }
+
+    pub fn to_bit_types(&self) -> [u8; 3] {
+        [self.a_bits(), self.b_bits(), self.c_bits()]
+    }
+
+    const fn to_a_type(self) -> AType {
+        match self.a_bits() {
+            0 => AType::Zero,
+            1 => AType::One,
+            2 => AType::Two,
+            3 => AType::Three,
+            4 => AType::Four,
+            5 => AType::Five,
+            6 => AType::Six,
+            7 => AType::Seven,
+            // The value returned from [to_a_bits] will never be larger than a
+            // 3-bit value.
+            _ => unreachable!(),
+        }
+    }
+
+    const fn to_b_type(self) -> BType {
+        match self.b_bits() {
+            0 => BType::Zero,
+            1 => BType::One,
+            2 => BType::Two,
+            3 => BType::Three,
+            4 => BType::Four,
+            5 => BType::Five,
+            6 => BType::Six,
+            7 => BType::Seven,
+            // The value returned from [to_b_bits] will never be larger than a
+            // 3-bit value.
+            _ => unreachable!(),
+        }
+    }
+
+    const fn to_c_type(self) -> CType {
+        match self.c_bits() {
+            0 => CType::Zero,
+            1 => CType::One,
+            2 => CType::Two,
+            // The value returned from [to_c_bits] will never be larger than a
+            // 2-bit value with the last value being unused.
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<u8> for Opcode {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AType {
+    Zero,
+    One,
+    Two,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BType {
+    Zero,
+    One,
+    Two,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CType {
+    Zero,
+    One,
+    Two,
+}
+
+const fn mnemonic_from_types(a_type: AType, c_type: CType) -> Option<crate::mnemonic::Mnemonic> {
+    use crate::mnemonic::Mnemonic;
+
+    match c_type {
+        CType::Zero => match a_type {
+            AType::One => Some(Mnemonic::Bit),
+            AType::Two => Some(Mnemonic::Jmp),
+            AType::Three => Some(Mnemonic::Jmp),
+            AType::Four => Some(Mnemonic::Sty),
+            AType::Five => Some(Mnemonic::Ldy),
+            AType::Six => Some(Mnemonic::Cpy),
+            AType::Seven => Some(Mnemonic::Cpx),
+            _ => None,
+        },
+        CType::One => match a_type {
+            AType::Zero => Some(Mnemonic::Ora),
+            AType::One => Some(Mnemonic::And),
+            AType::Two => Some(Mnemonic::Eor),
+            AType::Three => Some(Mnemonic::Adc),
+            AType::Four => Some(Mnemonic::Sta),
+            AType::Five => Some(Mnemonic::Lda),
+            AType::Six => Some(Mnemonic::Cmp),
+            AType::Seven => Some(Mnemonic::Sbc),
+        },
+        CType::Two => match a_type {
+            AType::Zero => Some(Mnemonic::Asl),
+            AType::One => Some(Mnemonic::Rol),
+            AType::Two => Some(Mnemonic::Lsr),
+            AType::Three => Some(Mnemonic::Ror),
+            AType::Four => Some(Mnemonic::Stx),
+            AType::Five => Some(Mnemonic::Ldx),
+            AType::Six => Some(Mnemonic::Dec),
+            AType::Seven => Some(Mnemonic::Inc),
+        },
+    }
+}
+
+const fn address_mode_from_types(
+    b_type: BType,
+    c_type: CType,
+) -> Option<crate::addressing_mode::AddressingModeType> {
+    use crate::addressing_mode::AddressingModeType;
+
+    match c_type {
+        CType::Zero => match b_type {
+            BType::Zero => Some(AddressingModeType::Immediate),
+            BType::One => Some(AddressingModeType::ZeroPage),
+            BType::Three => Some(AddressingModeType::Absolute),
+            BType::Five => Some(AddressingModeType::ZeroPageIndexedWithX),
+            BType::Seven => Some(AddressingModeType::AbsoluteIndexedWithX),
+            _ => None,
+        },
+        CType::One => match b_type {
+            BType::Zero => Some(AddressingModeType::XIndexedIndirect),
+            BType::One => Some(AddressingModeType::ZeroPage),
+            BType::Two => Some(AddressingModeType::Immediate),
+            BType::Three => Some(AddressingModeType::Absolute),
+            BType::Four => Some(AddressingModeType::IndirectYIndexed),
+            BType::Five => Some(AddressingModeType::ZeroPageIndexedWithX),
+            BType::Six => Some(AddressingModeType::AbsoluteIndexedWithY),
+            BType::Seven => Some(AddressingModeType::AbsoluteIndexedWithX),
+        },
+        CType::Two => match b_type {
+            BType::Zero => Some(AddressingModeType::Immediate),
+            BType::One => Some(AddressingModeType::ZeroPage),
+            BType::Two => Some(AddressingModeType::Accumulator),
+            BType::Three => Some(AddressingModeType::Absolute),
+            BType::Five => Some(AddressingModeType::ZeroPageIndexedWithX),
+            BType::Seven => Some(AddressingModeType::AbsoluteIndexedWithX),
+            _ => None,
+        },
+    }
+}
+
+pub const fn decode(
+    opcode: &Opcode,
+) -> Option<(
+    crate::mnemonic::Mnemonic,
+    crate::addressing_mode::AddressingModeType,
+)> {
+    let a_type = opcode.to_a_type();
+    let b_type = opcode.to_b_type();
+    let c_type = opcode.to_c_type();
+    let mnemonic = mnemonic_from_types(a_type, c_type);
+    let addressing_mode = address_mode_from_types(b_type, c_type);
+
+    if let (Some(mnemonic), Some(am)) = (mnemonic, addressing_mode) {
+        Some((mnemonic, am))
+    } else {
+        None
+    }
+}

--- a/src/bit_decoder.rs
+++ b/src/bit_decoder.rs
@@ -103,8 +103,60 @@ enum CType {
     Two,
 }
 
-const fn mnemonic_from_types(a_type: AType, c_type: CType) -> Option<crate::mnemonic::Mnemonic> {
+const fn mnemonic_from_opcode(opcode: &Opcode) -> Option<crate::mnemonic::Mnemonic> {
     use crate::mnemonic::Mnemonic;
+
+    // Check for exceptions to the bit patterned rules
+    let exception = match opcode.0 {
+        // branching
+        0x10 => Some(Mnemonic::Bpl),
+        0x30 => Some(Mnemonic::Bmi),
+        0x50 => Some(Mnemonic::Bvc),
+        0x70 => Some(Mnemonic::Bvs),
+        0x90 => Some(Mnemonic::Bcc),
+        0xB0 => Some(Mnemonic::Bcs),
+        0xD0 => Some(Mnemonic::Bne),
+        0xF0 => Some(Mnemonic::Beq),
+
+        // interrupt
+        0x00 => Some(Mnemonic::Brk),
+        0x20 => Some(Mnemonic::Jsr),
+        0x40 => Some(Mnemonic::Rti),
+        0x60 => Some(Mnemonic::Rts),
+
+        // other
+        0x08 => Some(Mnemonic::Php),
+        0x28 => Some(Mnemonic::Plp),
+        0x48 => Some(Mnemonic::Pha),
+        0x68 => Some(Mnemonic::Pla),
+        0x88 => Some(Mnemonic::Dey),
+        0xA8 => Some(Mnemonic::Tay),
+        0xC8 => Some(Mnemonic::Iny),
+        0xE8 => Some(Mnemonic::Inx),
+        0x18 => Some(Mnemonic::Clc),
+        0x38 => Some(Mnemonic::Sec),
+        0x58 => Some(Mnemonic::Cli),
+        0x78 => Some(Mnemonic::Sei),
+        0x98 => Some(Mnemonic::Tya),
+        0xB8 => Some(Mnemonic::Clv),
+        0xD8 => Some(Mnemonic::Cld),
+        0xF8 => Some(Mnemonic::Sed),
+        0x8A => Some(Mnemonic::Txa),
+        0x9A => Some(Mnemonic::Txs),
+        0xAA => Some(Mnemonic::Tax),
+        0xBA => Some(Mnemonic::Tsx),
+        0xCA => Some(Mnemonic::Dex),
+        0xEA => Some(Mnemonic::Nop),
+
+        _ => None,
+    };
+
+    if exception.is_some() {
+        return exception;
+    }
+
+    let a_type = opcode.to_a_type();
+    let c_type = opcode.to_c_type();
 
     match c_type {
         CType::Zero => match a_type {
@@ -140,11 +192,43 @@ const fn mnemonic_from_types(a_type: AType, c_type: CType) -> Option<crate::mnem
     }
 }
 
-const fn address_mode_from_types(
-    b_type: BType,
-    c_type: CType,
+const fn address_mode_from_opcode(
+    opcode: &Opcode,
 ) -> Option<crate::addressing_mode::AddressingModeType> {
     use crate::addressing_mode::AddressingModeType;
+
+    // Check for exceptions to the bit patterned rules
+    let exception = match opcode.0 {
+        // branching
+        0x10 | 0x30 | 0x50 | 0x70 | 0x90 | 0xB0 | 0xD0 | 0xF0 => Some(AddressingModeType::Relative),
+
+        // interrupt
+        0x20 => Some(AddressingModeType::Absolute),
+        0x00 | 0x40 | 0x60 => Some(AddressingModeType::Implied),
+
+        // other
+        0x08 | 0x28 | 0x48 | 0x68 | 0x88 | 0xA8 | 0xC8 | 0xE8 | 0x18 | 0x38 | 0x58 | 0x78
+        | 0x98 | 0xB8 | 0xD8 | 0xF8 | 0x8A | 0x9A | 0xAA | 0xBA | 0xCA | 0xEA => {
+            Some(AddressingModeType::Implied)
+        }
+
+        // jmp indirect
+        0x6C => Some(AddressingModeType::Indirect),
+
+        // Indexed zeropage stx/ldx
+        0xB6 | 0x96 => Some(AddressingModeType::ZeroPageIndexedWithY),
+        // absolute indexed ldx
+        0xBE => Some(AddressingModeType::AbsoluteIndexedWithY),
+
+        _ => None,
+    };
+
+    if exception.is_some() {
+        return exception;
+    }
+
+    let b_type = opcode.to_b_type();
+    let c_type = opcode.to_c_type();
 
     match c_type {
         CType::Zero => match b_type {
@@ -183,15 +267,11 @@ pub const fn decode(
     crate::mnemonic::Mnemonic,
     crate::addressing_mode::AddressingModeType,
 )> {
-    let a_type = opcode.to_a_type();
-    let b_type = opcode.to_b_type();
-    let c_type = opcode.to_c_type();
-    let mnemonic = mnemonic_from_types(a_type, c_type);
-    let addressing_mode = address_mode_from_types(b_type, c_type);
+    let mnemonic = mnemonic_from_opcode(opcode);
+    let addressing_mode = address_mode_from_opcode(opcode);
 
-    if let (Some(mnemonic), Some(am)) = (mnemonic, addressing_mode) {
-        Some((mnemonic, am))
-    } else {
-        None
+    match (mnemonic, addressing_mode) {
+        (Some(mnemonic), Some(am)) => Some((mnemonic, am)),
+        _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,7 @@ macro_rules! generate_instructions {
                 }
             }
 
+            #[cfg(feature = "parcel")]
             impl<'a> parcel::Parser<'a, &'a [(usize, u8)], $crate::Instruction<$crate::mnemonic::$mnc, $crate::addressing_mode::$am>>
                 for $crate::Instruction<$crate::mnemonic::$mnc, $crate::addressing_mode::$am>
             {
@@ -278,14 +279,18 @@ macro_rules! generate_instructions {
         #[cfg(test)]
         mod tests {
             mod parser {
+                #[cfg(feature = "parcel")]
                 use parcel::prelude::v1::Parser;
                 $(
                     #[test]
                     fn $name() {
                         let bytecode = [$opcode, 0x00, 0x00];
-                        let enumerated_bytes: Vec<(usize, u8)> = bytecode.iter().copied().enumerate().collect();
                         let expected = $crate::Instruction::new(<$crate::mnemonic::$mnc>::default(), <$crate::addressing_mode::$am>::default());
 
+                        #[cfg(feature = "parcel")]
+                        let enumerated_bytes: Vec<(usize, u8)> = bytecode.iter().copied().enumerate().collect();
+
+                        #[cfg(feature = "parcel")]
                         // assert parcel parse matches expected
                         assert_eq!(
                             expected,

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "parcel")]
 extern crate parcel;
+
 use crate::ByteSized;
 
 /// Represents various conversion errors between mnemnoic types.
@@ -19,6 +21,7 @@ macro_rules! generate_mnemonic_parser_and_offset {
     ($mnemonic:ty, $text:literal, $opcode:literal) => {
         impl ByteSized for $mnemonic {}
 
+        #[cfg(feature = "parcel")]
         impl<'a> parcel::Parser<'a, &'a [(usize, u8)], $mnemonic> for $mnemonic {
             fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], $mnemonic> {
                 parcel::map(
@@ -28,6 +31,7 @@ macro_rules! generate_mnemonic_parser_and_offset {
             }
         }
 
+        #[cfg(feature = "parcel")]
         impl<'a> parcel::Parser<'a, &'a [(usize, char)], $mnemonic> for $mnemonic {
             fn parse(&self, input: &'a [(usize, char)]) -> parcel::ParseResult<&'a [(usize, char)], $mnemonic> {
                 parcel::map(
@@ -41,6 +45,7 @@ macro_rules! generate_mnemonic_parser_and_offset {
     ($mnemonic:ty, $text:literal, $( $opcode:literal ),* ) => {
         impl ByteSized for $mnemonic {}
 
+        #[cfg(feature = "parcel")]
         impl<'a> parcel::Parser<'a, &'a [(usize, u8)], $mnemonic> for $mnemonic {
             fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], $mnemonic> {
                 parcel::one_of(vec![
@@ -53,6 +58,7 @@ macro_rules! generate_mnemonic_parser_and_offset {
             }
         }
 
+        #[cfg(feature = "parcel")]
         impl<'a> parcel::Parser<'a, &'a [(usize, char)], $mnemonic> for $mnemonic {
             fn parse(&self, input: &'a [(usize, char)]) -> parcel::ParseResult<&'a [(usize, char)], $mnemonic> {
                 parcel::map(


### PR DESCRIPTION
# Introduction
This PR flips parcel over to be a default-on feature and implements a binary decoding format built loosely around https://llx.com/Neil/a2/opcodes.html.

Additionally this flips the release process to be manually triggered rather than rolling.
# Linked Issues
#35 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
